### PR TITLE
chore(typings): add JSDoc annotation & build script for generating typings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/esm/index.js
+++ b/esm/index.js
@@ -11,7 +11,7 @@ import {
 } from 'lighterhtml';
 
 /**
- * @typedef {<K, T extends any[] = any[]>(template: TemplateStringsArray, ...values: T) => K} ITagFunction
+ * @typedef {<K>(template: TemplateStringsArray, ...values: any[]) => K} ITagFunction
  */
 
 /**
@@ -48,15 +48,28 @@ const {isArray} = Array;
  */
 export const neverland = fn => (...args) => new Hook(fn, args);
 
-html.for = createFor($html);
+/**
+ * @typedef {{
+ *  (...args: any[]): Hole;
+ *  for: (entry: IEntry, id: string) => (...args: any[]) => any
+ * }} IRenderer
+ */
+
+/**
+ * @type {IRenderer}
+ */
 export function html() {
   return new Hole('html', tta.apply(null, arguments));
 };
+html.for = createFor($html);
 
-svg.for = createFor($svg);
+/**
+ * @type {IRenderer}
+ */
 export function svg() {
   return new Hole('svg', tta.apply(null, arguments));
 };
+svg.for = createFor($svg);
 
 /**
  * @type {WeakMap<object, IInfo>}
@@ -92,6 +105,7 @@ export const render = (where, what) => {
 };
 
 export {
+  // @ts-ignore why is this not typed in dom-augmentor?
   contextual,
   useState,
   useEffect,
@@ -174,7 +188,7 @@ const unroll = ({stack}, {fn, args}, counter) => {
 
 /**
  * @param {IInfo} info
- * @param {any[]} args
+ * @param {any} args
  * @param {ICounter} counter
  */
 const unrollArray = (info, args, counter) => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,48 @@
+export const html: IRenderer;
+export const svg: IRenderer;
+export function neverland(fn: <T>(...args: any[]) => T): (...args: any[]) => Hook;
+export function render(where: Node, what: any): Node;
+export type IRenderer = {
+    (...args: any[]): Hole;
+    for: (entry: IEntry, id: string) => (...args: any[]) => any;
+};
+export type ITagFunction = <K>(template: TemplateStringsArray, ...values: any[]) => K;
+/**
+ * An interface describing hooks counter
+ */
+export type ICounter = {
+    a: number;
+    aLength: number;
+    i: number;
+    iLength: number;
+};
+/**
+ * An interface describing hooks info
+ */
+export type IInfo = {
+    sub?: IInfo[];
+    stack: IEntry[];
+};
+export type IEntry = {
+    hook: any;
+    fn: any;
+};
+export type CacheFn = <T>(wm: any, key: any, value: T) => T;
+import { Hole } from "lighterhtml";
+/**
+ * @class
+ * @param {Function} fn
+ * @param {any[]} args
+ */
+declare function Hook(fn: Function, args: any[]): void;
+declare class Hook {
+    /**
+     * @class
+     * @param {Function} fn
+     * @param {any[]} args
+     */
+    constructor(fn: Function, args: any[]);
+    fn: Function;
+    args: any[];
+}
+export { useState, useEffect, useContext, createContext, useRef, useReducer, useCallback, useMemo, useLayoutEffect } from "dom-augmentor";

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "main": "cjs/index.js",
   "module": "esm/index.js",
   "unpkg": "min.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "npm run rollup && drop-babel-typeof index.js && npm run cjs && npm run min && npm run test && npm run size",
+    "build:typings": "tsc --allowJs --emitDeclarationOnly",
     "cjs": "ascjs esm cjs",
     "min": "echo '/*! (c) Andrea Giammarchi - ISC */' > min.js && uglifyjs index.js -c -m >> min.js",
     "rollup": "rollup --config rollup.config.js",
@@ -47,6 +49,7 @@
     "rollup": "^1.27.11",
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-node-resolve": "^5.2.0",
+    "typescript": "^3.7.3",
     "uglify-es": "^3.3.9"
   },
   "repository": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "ES6",
+    "target": "esnext",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "."
+  },
+  "include": [
+    "esm"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
The output is not optimal, so there needs to be a bit of manual tweak after generation.

JsDoc was added for 2 purposes:
- ability to have intellisense for source code, without having to use TS
- ability to generate better typings to tweak for typings distribution

Added `.vscode/settings.json` for specifying TS SDK to use
Added typescript as dep dependency to run build script
Added build script to generate typings