### PR TITLE
Better typings for neverland

### DIFF
--- a/esm/index.js
+++ b/esm/index.js
@@ -44,7 +44,9 @@ const {create} = Object;
 const {isArray} = Array;
 
 /**
- * @param {<T>(...args: any[]) => T} fn
+ * @template Args
+ * @param {(...args: Args[]) => unknown} fn
+ * @returns {(...args: Args[]) => Hook}
  */
 export const neverland = fn => (...args) => new Hook(fn, args);
 


### PR DESCRIPTION
There is an error, when you using neverland function with typescript. All i did is used proper generics in jsdoc instead of any and <T>() => T.

Before 
![Screenshot_5](https://user-images.githubusercontent.com/8134947/71051753-5f6d6700-215a-11ea-8283-e67fabd079d6.png)

After
![Screenshot_4](https://user-images.githubusercontent.com/8134947/71051769-66947500-215a-11ea-976f-7ffb6437f534.png)

First day - love your work.